### PR TITLE
workaround for dovecot-2.2 EPIPE bug.

### DIFF
--- a/imap-xaps-plugin.c
+++ b/imap-xaps-plugin.c
@@ -127,6 +127,7 @@ static int xaps_register(const char *socket_path, const char *aps_account_id, co
 
   alarm(2);
   {
+    errno = 0;
     if (net_transmit(fd, str_data(req), str_len(req)) < 0) {
       i_error("write(%s) failed: %m", socket_path);
       ret = -1;


### PR DESCRIPTION
see also: http://www.dovecot.org/list/dovecot-cvs/2014-January/024154.html

Please note: I'm using this with dovecot-1:2.2.9-1ubuntu2.1 (trusty). but I send notify by another script, due to my procmail -> Maildir dataflow. so I didn't test lda/lmtp route.