### PR TITLE
lower require cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
 project(dovecot-xaps-plugin)
 
 include_directories(/usr/include/dovecot)


### PR DESCRIPTION
To be able to build against Debian Jessie, we need to require CMake <= 3.7.2 (Jessie Backports).
Shouldn't be a problem since the available directives seem to be nearly the same.
Fixes #35 