### PR TITLE
implement user lookup for alias mailboxes

### DIFF
--- a/xaps-daemon.c
+++ b/xaps-daemon.c
@@ -114,7 +114,7 @@ static void xaps_str_append_quoted(string_t *dest, const char *str) {
  * devices want to receive a notification for that mailbox.
  */
 
-int xaps_notify(const char *socket_path, struct mail_user *mailuser, struct mailbox *mailbox, struct push_notification_txn_msg *msg) {
+int xaps_notify(const char *socket_path, const char *username, struct mail_user *mailuser , struct mailbox *mailbox, struct push_notification_txn_msg *msg) {
     struct push_notification_txn_event *const *event;
     /*
      * Construct the request.
@@ -122,7 +122,7 @@ int xaps_notify(const char *socket_path, struct mail_user *mailuser, struct mail
     string_t *req = t_str_new(1024);
     str_append(req, "NOTIFY");
     str_append(req, " dovecot-username=");
-    xaps_str_append_quoted(req, mailuser->username);
+    xaps_str_append_quoted(req, username);
     str_append(req, "\tdovecot-mailbox=");
     xaps_str_append_quoted(req, mailbox->name);
     if (array_is_created(&msg->eventdata)) {

--- a/xaps-daemon.h
+++ b/xaps-daemon.h
@@ -42,7 +42,7 @@ struct xaps_attr {
 
 int send_to_deamon(const char *socket_path, const string_t *payload, struct xaps_attr *xaps_attr);
 
-int xaps_notify(const char *socket_path, struct mail_user *mailuser, struct mailbox *mailbox, struct push_notification_txn_msg *msg);
+int xaps_notify(const char *socket_path, const char *username, struct mail_user *mailuser, struct mailbox *mailbox, struct push_notification_txn_msg *msg);
 
 int xaps_register(const char *socket_path, struct xaps_attr *xaps_attr);
 

--- a/xaps-push-notification-plugin.c
+++ b/xaps-push-notification-plugin.c
@@ -93,7 +93,11 @@ static void xaps_plugin_process_msg(struct push_notification_driver_txn *dtxn, s
                                            "Handling event: %s", (*event)->event->event->name);
         }
     }
-    if (xaps_notify(socket_path, dtxn->ptxn->muser, dtxn->ptxn->mbox, msg) != 0) {
+    const char *username = dtxn->ptxn->muser->username;
+    if (user_lookup != NULL) {
+        username = mail_user_plugin_getenv(dtxn->ptxn->muser, user_lookup);
+    }
+    if (xaps_notify(socket_path, username, dtxn->ptxn->muser, dtxn->ptxn->mbox, msg) != 0) {
         i_error("cannot notify");
     }
 }
@@ -113,6 +117,7 @@ int xaps_plugin_init(struct push_notification_driver_config *dconfig ATTR_UNUSED
     if (socket_path == NULL) {
         socket_path = DEFAULT_SOCKPATH;
     }
+    user_lookup = mail_user_plugin_getenv(muser, "xaps_user_lookup");
     return 0;
 }
 

--- a/xaps-push-notification-plugin.h
+++ b/xaps-push-notification-plugin.h
@@ -30,6 +30,7 @@ struct module;
 
 extern const char *xaps_plugin_dependencies[];
 const char *socket_path;
+const char *user_lookup;
 
 void xaps_push_notification_plugin_init(struct module *module);
 void xaps_push_notification_plugin_deinit(void);

--- a/xaps.conf
+++ b/xaps.conf
@@ -13,6 +13,9 @@ protocol lmtp {
 plugin {
 	# Defaults to /var/run/dovecot/xapsd.sock
 	#xaps_socket =
+	# Defaults to NULL. Use if you want to determine the username used for PNs from environment variables provided by
+	# login mechanism. Value is variable name to look up.
+	#xaps_user_lookup =
 	push_notification_driver = xaps
 }
 


### PR DESCRIPTION
There are people creating seperate mailboxes for aliases. Those have the original username set in an attribute. If a PN is triggered it would be send to the alias email which is no known by the xapsd. With this PR we allow to set the attribute from which the username can be read (optionally).